### PR TITLE
Hex lines and hashing

### DIFF
--- a/util/hexagon.py
+++ b/util/hexagon.py
@@ -14,6 +14,15 @@ class _Hex:
         delta = self - tile
         return max(abs(c) for c in delta.cube)
 
+    def straight_line(self, neighbor, max_distance=20):
+        assert neighbor in self.neighbors
+        counter = 0
+        delta = neighbor - self
+        while counter < max_distance:
+            counter += 1
+            neighbor += delta
+            yield neighbor
+
     @property
     def neighbors(self):
         if self.__neighbors is None:
@@ -113,4 +122,8 @@ if __name__ == '__main__':
     print(tile2 == tile3)
     print(tile2 is tile3)
     print(tile2 in tile1.neighbors)
-
+    source = Hex(1, 1)
+    neighbor = Hex(1, 2)
+    dir = neighbor - source
+    target = neighbor + dir
+    print(f'{source} -> {neighbor} -> {target}')

--- a/util/hexagon.py
+++ b/util/hexagon.py
@@ -110,25 +110,28 @@ def Hex(x, y):
     return new_hex
 
 
-# HEX API
+# Hex example usage
 if __name__ == '__main__':
     tile1 = Hex(1, 1)
-    print(tile1)
-    print(tile1.xy)
     tile2 = Hex(1, 2)
     tile3 = Hex(1, 2)
-    print(tile2)
-    print(tile2.x, tile2.y)
-    print(tile1.neighbors)
-    print(tile1.get_distance(tile2))
-    print(tile1 is tile2)
-    print(tile2 == tile3)
-    print(tile2 is tile3)
-    print(tile2 in tile1.neighbors)
-    source = Hex(1, 1)
-    neighbor = Hex(1, 2)
-    dir = neighbor - source
-    target = neighbor + dir
-    print(f'{source} -> {neighbor} -> {target}')
-    hex_set = {Hex(0, 0), Hex(0, 1), Hex(0, 2)}
-    print(Hex(0, 1) in hex_set)
+    print('=== Coordinates')
+    print(f'{tile1} xy: {tile1.xy}')
+    print(f'{tile2} x, y: {tile2.x}, {tile2.y}')
+    print('=== Neighbors')
+    print(f'{tile1} neighbors: {tile1.neighbors}')
+    print('=== Operations')
+    print(f'{tile2} in {tile1} neighbors: {tile2 in tile1.neighbors}')
+    print(f'{tile1} is {tile2}: {tile1 is tile2}')
+    print(f'{tile2} == {tile3}: {tile2 == tile3}')
+    print(f'{tile2} is {tile3}: {tile2 is tile3}')
+    print('=== Distances')
+    print(f'Distance {tile1} -> {tile2}: {tile1.get_distance(tile2)}')
+    print('=== Straight lines')
+    dir = tile2 - tile1
+    tile4 = tile2 + dir
+    print(f'Straight line from {tile1} -> {tile2} : {tile4}')
+    hex_set = {tile1, tile2, tile3, tile4}
+    print('=== Sets and containment')
+    print(f'Set: {hex_set}')
+    print(f'{tile1} in {hex_set} : {tile1 in hex_set}')

--- a/util/hexagon.py
+++ b/util/hexagon.py
@@ -85,6 +85,9 @@ class _Hex:
     def __repr__(self):
         return f'<Hex {self.x}, {self.y}>'
 
+    def __hash__(self):
+        return hash(self.__cube)
+
 
 DIRECTIONS = [
     _Hex(+1, 0, -1),
@@ -127,3 +130,5 @@ if __name__ == '__main__':
     dir = neighbor - source
     target = neighbor + dir
     print(f'{source} -> {neighbor} -> {target}')
+    hex_set = {Hex(0, 0), Hex(0, 1), Hex(0, 2)}
+    print(Hex(0, 1) in hex_set)


### PR DESCRIPTION
Hex class gets new `straight_line` generator, taking two neighbor tiles and generating tiles along that line (useful for pushing along hexes).

Hex objects now also hashable (in particular so that they can be contained in sets).