### PR TITLE
More logging

### DIFF
--- a/api/bots.py
+++ b/api/bots.py
@@ -1,5 +1,6 @@
 from util.hexagon import Hex
 from collections import namedtuple
+from api.logging import logger as glogger
 from api.actions import Move, Push
 
 
@@ -39,7 +40,7 @@ class BaseBot:
         Called when we are clicked on in the GUI.
         May return a list of vfx args.
         """
-        print(f'#{self.id} {self.name} received click_debug with button: {button}')
+        glogger(f'#{self.id} {self.name} received click_debug with button: {button}')
         return [
             {'name': 'mark-green', 'hex': hex, 'neighbor': None},
         ]

--- a/api/bots.py
+++ b/api/bots.py
@@ -24,6 +24,7 @@ class BaseBot:
     SPRITE = "circle"
     TESTING_ONLY = False
     COLOR_INDEX = 0
+    logging_enabled = False
 
     def __init__(self, id: int):
         self.id = id
@@ -35,15 +36,44 @@ class BaseBot:
     def get_action(self, world_state):
         return Move(Hex(0, 0))
 
-    def click_debug(self, hex, button):
+    def gui_click(self, hex, button):
         """
         Called when we are clicked on in the GUI.
         May return a list of vfx args.
         """
-        glogger(f'#{self.id} {self.name} received click_debug with button: {button}')
+        if button == 'left':
+            return self.gui_click_debug(hex)
+        elif button == 'right':
+            self.logging_enabled = not self.logging_enabled
+            glogger(f'{self} logging: {self.logging_enabled}')
+            vfx_name = 'mark-green' if self.logging_enabled else 'mark-red'
+            return [
+                {'name': vfx_name, 'hex': hex, 'neighbor': None, 'real_time': 0.5},
+            ]
+        elif button == 'middle':
+            return self.gui_click_debug_alt(hex)
+
+    def gui_click_debug(self, hex):
+        """
+        Called by gui_click when we are clicked on in the GUI with the left
+        mouse button. May return a list of vfx args.
+        """
         return [
-            {'name': 'mark-green', 'hex': hex, 'neighbor': None},
+            {'name': 'mark-blue', 'hex': hex, 'neighbor': None},
         ]
+
+    def gui_click_debug_alt(self, hex):
+        """
+        Called by gui_click when we are clicked on in the GUI with the middle
+        mouse button. May return a list of vfx args.
+        """
+        return [
+            {'name': 'mark-blue', 'hex': hex, 'neighbor': None},
+        ]
+
+    def logger(self, text):
+        if self.logging_enabled:
+            glogger(text)
 
     def __repr__(self):
         return f'<Bot #{self.id} {self.name}>'

--- a/api/logging.py
+++ b/api/logging.py
@@ -1,0 +1,15 @@
+from util.settings import Settings
+
+
+GLOBAL_LOGGING = Settings.get('logging.global', True)
+
+
+class Logger:
+    enable_logging = GLOBAL_LOGGING
+
+    def __call__(self, text):
+        if self.enable_logging:
+            print(text)
+
+
+logger = Logger()

--- a/api/logic.py
+++ b/api/logic.py
@@ -146,7 +146,10 @@ class BaseLogicAPI:
             fg_sprite = 'hex'
         elif hex in self.positions:
             unit_id = self.positions.index(hex)
-            fg_color = self.unit_colors[unit_id]
+            if not self.alive_mask[unit_id]:
+                fg_color = 0.5, 0.5, 0.5
+            else:
+                fg_color = self.unit_colors[unit_id]
             fg_text = f'{unit_id}'
             fg_sprite = self.unit_sprites[unit_id]
         else:

--- a/api/logic.py
+++ b/api/logic.py
@@ -26,7 +26,7 @@ def gui_control_menu_extend(menu1, menu2):
 
 STEP_RATE = Settings.get('logic._step_rate_cap', 20)
 STEP_RATES = Settings.get('logic.|step_rates', [1, 3, 10, 20, 60])
-LOGIC_DEBUG = Settings.get('logic.battle_debug', True)
+LOGIC_DEBUG = Settings.get('logging.battle', True)
 
 RNG = np.random.default_rng()
 MAX_STEPS = 1000

--- a/api/logic.py
+++ b/api/logic.py
@@ -1,5 +1,6 @@
 from collections import deque, namedtuple
 import numpy as np
+from api.logging import logger as glogger
 from util.time import ping, pong
 from util.settings import Settings
 from util.hexagon import Hex, is_hex
@@ -209,4 +210,4 @@ class BaseLogicAPI:
     @staticmethod
     def logger(m):
         if LOGIC_DEBUG:
-            print(m)
+            glogger(m)

--- a/bots/__init__.py
+++ b/bots/__init__.py
@@ -1,5 +1,6 @@
 import random
 
+from api.logging import logger
 from api.bots import BaseBot
 from pkgutil import iter_modules
 from pathlib import Path
@@ -14,7 +15,7 @@ def bot_importer():
     """
     bots = {}
     package_dir = Path(__file__).resolve().parent
-    print('Available bots:')
+    logger('Available bots:')
     for (_, module_name, _) in iter_modules([str(package_dir)]):
         module = import_module(f"{__name__}.{module_name}")
         if hasattr(module, "BOT"):
@@ -28,7 +29,7 @@ def bot_importer():
             if bot.NAME in bots:
                 raise KeyError(f'Bot name: "{bot.NAME}" (from module: {module_name}) already in use.')
             bots[bot.NAME] = bot
-            print(f'- {bot.NAME} (from module: {module_name})')
+            logger(f'- {bot.NAME} (from module: {module_name})')
     return bots
 
 
@@ -46,17 +47,17 @@ def make_bots(num_of_bots: int) -> list[BaseBot]:
     if len(BOTS) == 0:
         game_classes = [BaseBot] * num_of_bots
     else:
-        print('Requested bots:')
-        print('\n'.join(f'#{i:<2} {r}' for i, r in enumerate(BOT_REQ[:num_of_bots])))
-        print('Ignoring bots:')
-        print('\n'.join(ibn for ibn in BOTS_IGNORED))
+        logger('Requested bots:')
+        logger('\n'.join(f'#{i:<2} {r}' for i, r in enumerate(BOT_REQ[:num_of_bots])))
+        logger('Ignoring bots:')
+        logger('\n'.join(ibn for ibn in BOTS_IGNORED))
         game_classes = [BOTS[req] for req in BOT_REQ if req in BOTS]
         non_testing_bots = [bot for bot in BOTS.values() if not bot.TESTING_ONLY and bot.NAME not in BOTS_IGNORED]
         random.shuffle(non_testing_bots)
         while len(game_classes) < num_of_bots:
             idx = (num_of_bots - len(game_classes)) % len(non_testing_bots)
             game_classes.append(non_testing_bots[idx])
-    print('Selected bots:')
-    print('\n'.join(f'#{i:<2} {cls.NAME}' for i, cls in enumerate(game_classes[:num_of_bots])))
+    logger('Selected bots:')
+    logger('\n'.join(f'#{i:<2} {cls.NAME}' for i, cls in enumerate(game_classes[:num_of_bots])))
     bots_instances = [game_classes[i](i) for i in range(num_of_bots)]
     return bots_instances

--- a/bots/crazee_bot_alpha.py
+++ b/bots/crazee_bot_alpha.py
@@ -4,6 +4,7 @@ import numpy as np
 from api.actions import Move, Push, Idle, Action
 from bots import BaseBot
 from util.hexagon import Hexagon, Hex
+from api.logging import logger as glogger
 from api.bots import world_info
 from util.settings import Settings
 from time import perf_counter
@@ -13,7 +14,7 @@ DEBUG = Settings.get('bots.crazee.debug', False)
 
 def debug(*lines):
     if DEBUG:
-        print('\n'.join(str(_) for _ in lines))
+        glogger('\n'.join(str(_) for _ in lines))
 
 
 class CrazeeBotAlpha(BaseBot):
@@ -103,14 +104,14 @@ class CrazeeBotAlpha(BaseBot):
             c_pos = new_cwi.positions
             c_ap = new_cwi.ap
             if type(action) is Push:
-                # print(f"My Pos: {c_pos[self.id]}, Target: {action.action.target}")
+                # debug(f"My Pos: {c_pos[self.id]}, Target: {action.action.target}")
                 end_tile = next(c_pos[self.id].straight_line(action.target))
                 enemy_index = [e for e in range(len(c_pos)) if c_pos[e] == action.target][0]
                 c_pos[enemy_index] = end_tile
             elif type(action) is Move:
                 c_pos[self.id] = action.target
             else:
-                print(action)
+                debug(action)
             c_ap[self.id] -= action.ap
             new_cwi.alive_mask[:] = [pos not in new_cwi.pits for pos in c_pos]
             return new_cwi
@@ -154,7 +155,7 @@ class CrazeeBotAlpha(BaseBot):
             if len(d_enemys) > 0:
                 enemy_score += (sum(d_enemys) / len(d_enemys))
             score = terrain_score + enemy_score + enemy_dead_score + ap_score
-            # print(f"Score: {score:.2f}, terrain: {terrain_score:.2f}, enemy: {enemy_score:.2f}, "
+            # debug(f"Score: {score:.2f}, terrain: {terrain_score:.2f}, enemy: {enemy_score:.2f}, "
             #       f"enemy_dead: {enemy_dead_score:.2f}, ap: {ap_score:.2f}")
             return score
 

--- a/bots/crazee_bot_alpha.py
+++ b/bots/crazee_bot_alpha.py
@@ -9,7 +9,7 @@ from api.bots import world_info
 from util.settings import Settings
 from time import perf_counter
 
-DEBUG = Settings.get('bots.crazee.debug', False)
+DEBUG = Settings.get('logging.bots.crazee.debug', False)
 
 
 def debug(*lines):

--- a/bots/crazee_bot_legacy.py
+++ b/bots/crazee_bot_legacy.py
@@ -5,6 +5,7 @@ import numpy as np
 from api.actions import Move, Push, Idle, Action
 from bots import BaseBot
 from util.hexagon import Hexagon, Hex
+from api.logging import logger as glogger
 from api.bots import world_info
 from util.settings import Settings
 from time import perf_counter
@@ -14,7 +15,7 @@ DEBUG = Settings.get('bots.crazee.l.debug', False)
 
 def debug(*lines):
     if DEBUG:
-        print('\n'.join(str(_) for _ in lines))
+        glogger('\n'.join(str(_) for _ in lines))
 
 
 class CrazeeBotLegacy(BaseBot):

--- a/bots/crazee_bot_legacy.py
+++ b/bots/crazee_bot_legacy.py
@@ -10,7 +10,7 @@ from api.bots import world_info
 from util.settings import Settings
 from time import perf_counter
 
-DEBUG = Settings.get('bots.crazee.l.debug', False)
+DEBUG = Settings.get('logging.bots.crazee.l.debug', False)
 
 
 def debug(*lines):

--- a/bots/ninja001_bot.py
+++ b/bots/ninja001_bot.py
@@ -2,6 +2,7 @@
 from collections import namedtuple
 import numpy as np
 from bots import BaseBot
+from api.logging import logger
 from api.actions import Idle, Move, Push
 from util.settings import Settings
 from util.hexagon import Hex
@@ -13,7 +14,7 @@ DEBUG = Settings.get('bots.ninja.debug', 0)
 
 def mlogger(*lines):
     if DEBUG:
-        print('\n'.join(str(_) for _ in lines))
+        logger('\n'.join(str(_) for _ in lines))
 
 
 class NinjaBotV001(BaseBot):

--- a/bots/ninja001_bot.py
+++ b/bots/ninja001_bot.py
@@ -2,19 +2,10 @@
 from collections import namedtuple
 import numpy as np
 from bots import BaseBot
-from api.logging import logger
 from api.actions import Idle, Move, Push
 from util.settings import Settings
 from util.hexagon import Hex
 from util.pathfinding import a_star
-
-
-DEBUG = Settings.get('bots.ninja.debug', 0)
-
-
-def mlogger(*lines):
-    if DEBUG:
-        logger('\n'.join(str(_) for _ in lines))
 
 
 class NinjaBotV001(BaseBot):
@@ -75,7 +66,7 @@ class NinjaBotV001(BaseBot):
             action = Push(push.tile)
             action_str = f'Pushing: {push.tile} {"LETHAL" if push.value > 0 else "not lethal"}'
 
-        mlogger(
+        self.logger('\n'.join([
             f'{action_str}',
             '',
             f'Turn step: {self.turn_step}',
@@ -86,7 +77,7 @@ class NinjaBotV001(BaseBot):
             '=== PUSH OPTIONS',
             '\n'.join(push_option_reprs),
             '_'*30,
-        )
+        ]))
         return action
 
     def move_options(self, wi):

--- a/bots/ninja002_bot.py
+++ b/bots/ninja002_bot.py
@@ -8,12 +8,7 @@ from util.hexagon import Hex
 from util.pathfinding import a_star
 
 
-DEBUG_LEVEL = Settings.get('bots.ninja.debug', 0)
-
-
-def mlogger(*lines, level=1):
-    if DEBUG_LEVEL >= level:
-        logger('\n'.join(str(_) for _ in lines))
+DEBUG_LEVEL = Settings.get('bots.ninja.debug_level', 1)
 
 
 class NinjaBotV002(BaseBot):
@@ -21,21 +16,9 @@ class NinjaBotV002(BaseBot):
     COLOR_INDEX = 10
     map_center = Hex(0, 0)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setup(self, wi):
         self.__last_step_round = -1
         self.turn_step = 0
-
-    def setup(self, wi):
-        # Guess ring of death radius
-        i = wi.positions[self.id].get_distance(self.map_center)
-        while i < 1000:  # arbitrary cap
-            i += 1
-            ring_tiles = self.map_center.ring(radius=i)
-            if all([t in wi.pits for t in ring_tiles]):
-                break
-        self.ring_radius_start = i+1
-        mlogger(f'Calculated RoD starting radius: {self.ring_radius_start}')
 
     def update(self, wi):
         if self.__last_step_round < 0:
@@ -46,6 +29,7 @@ class NinjaBotV002(BaseBot):
             self.turn_step += 1
         self.__last_step_round = wi.round_count
         self.wi = wi
+        self.ring_of_death = wi.ring_radius
         self.round_count = wi.round_count
         self.turn_count = wi.turn_count
         self.positions = wi.positions
@@ -65,69 +49,63 @@ class NinjaBotV002(BaseBot):
         self.tile_values = {}
         self.my_tile_value = self.move_tile_value(self.pos)
 
-    @property
-    def ring_of_death(self):
-        # TODO remove this and get from world_info when the feature is added
-        return self.ring_radius_start - self.round_count
-
     def log_status(self):
-        mlogger(
+        self.logger('\n'.join([
             f'=== STATUS ===',
             f'My AP: {self.ap:.1f} ; Turn step: {self.turn_step} ; Ring radius: {self.ring_of_death}',
             f'My position: {self.pos} (value: {self.my_tile_value:.3f})',
             '_'*30,
-        )
+        ]))
 
     def get_action(self, wi):
         self.update(wi)
         self.log_status()
         action = self.get_best_action()
-        mlogger(
-            '_'*30,
-            f'#{self.id} {self.name} : {self.ap} AP @ {self.round_count} / {self.turn_count} / {self.turn_step}',
+        self.logger(
+            '_'*30+f'\n{self} : {self.ap} AP @ {self.round_count} / {self.turn_count} / {self.turn_step}',
             level=2)
-        mlogger('_'*30)
+        self.logger('_'*30)
         return action
 
     def get_best_action(self):
         if self.ap == 0:
-            mlogger(f'Out of AP, staying put.')
+            self.logger(f'Out of AP, staying put.')
             return Idle()
         # Defend center
         if self.pos is self.map_center:
-            mlogger(f'Defending center.')
+            self.logger(f'Defending center.')
             return self.get_best_defence(self.pos)
 
         # Avoid RoD if necessary
         on_edge = self.pos.get_distance(self.map_center) == self.ring_of_death - 1
         if on_edge:
-            mlogger(f'On edge of map...')
+            self.logger(f'On edge of map...')
         if on_edge and self.ap <= 30:
             best_neighbor = sorted(self.pos.neighbors, key=lambda n: self.move_tile_value(n))[-1]
-            mlogger(f'Too close to edge, moving away to: {best_neighbor}.')
+            self.logger(f'Too close to edge, moving away to: {best_neighbor}.')
             return Move(best_neighbor)
 
         # Try push
         if self.ap >= 30:
             push_tile, push_value = self.get_best_pushes(self.pos)[0]
             if push_value > 0:
-                mlogger(f'Found good push: {push_tile} {push_value}')
+                self.logger(f'Found good push: {push_tile} {push_value}')
                 return Push(push_tile)
-            mlogger(f'No good push options.')
+            self.logger(f'No good push options.')
         else:
-            mlogger(f'Not enough AP for push.')
+            self.logger(f'Not enough AP for push.')
 
         # Try go to center
         path_to_center = self.path_as_close(self.map_center, sort=lambda x: -self.evaulate_path(x))
         if path_to_center:
             path_str = 'Best path:\n'+'\n'.join(f'-> {n.xy} : {self.move_tile_value(n):.3f} move value' for n in path_to_center)
-            mlogger(path_str, level=2)
+            self.logger(path_str, level=2)
             if self.evaulate_path(path_to_center) > self.my_tile_value:
-                mlogger(f'Moving as close as possible to center.')
+                self.logger(f'Moving as close as possible to center.')
                 return Move(path_to_center[0])
-            mlogger(f'No good paths toward the center, saving AP.')
+            self.logger(f'No good paths toward the center, saving AP.')
         else:
-            mlogger(f'No paths toward the center!')
+            self.logger(f'No paths toward the center!')
 
 
         # Spend AP if useful
@@ -136,12 +114,12 @@ class NinjaBotV002(BaseBot):
         move_cost = self.move_tile_cost(best_neighbor)
         if move_cost < float('inf'):
             if better_value:
-                mlogger(f'Free AP, repositioning: {self.pos} -> {best_neighbor}.')
+                self.logger(f'Free AP, repositioning: {self.pos} -> {best_neighbor}.')
                 return Move(best_neighbor)
             else:
-                mlogger(f'No better neighbor tiles to reposition.')
+                self.logger(f'No better neighbor tiles to reposition.')
 
-        mlogger(f'Found no good actions, staying put.')
+        self.logger(f'Found no good actions, staying put.')
         return Idle()
 
     def evaulate_path(self, path):
@@ -155,7 +133,7 @@ class NinjaBotV002(BaseBot):
             stop_tile_value = self.move_tile_value(path[turn_distance_cover-1])
         final_value = (last_tile_value + stop_tile_value*5) / 6
 
-        mlogger(' '.join([
+        self.logger(' '.join([
             f'Evaluating path: {path[0].xy} ->',
             f'{path[-1].xy} {stop_tile_value:.3f} {last_tile_value:.3f}',
             f'(covering {turn_distance_cover} / {len(path)} tiles)',
@@ -170,18 +148,18 @@ class NinjaBotV002(BaseBot):
             if 0 < len(enemies) < 6:
                 push_tile, push_value = self.get_best_pushes(self.pos)[0]
                 if push_value > 0:
-                    mlogger(f'Defending with push.')
+                    self.logger(f'Defending with push.')
                     return Push(push_tile)
-            mlogger(f'Defending, nobody worth pushing.')
+            self.logger(f'Defending, nobody worth pushing.')
             return Idle()
-        mlogger(f'Defending, not enough AP for push.')
+        self.logger(f'Defending, not enough AP for push.')
         return Idle()
 
     def get_best_pushes(self, tile):
         pvs = ((n, self.push_value(tile, n)) for n in tile.neighbors)
         push_options = sorted(pvs, key=lambda pv: -pv[1])
         push_str = '\n'.join(f'- {t} {v}' for t, v in push_options)
-        mlogger(f'Push options:', push_str, level=2)
+        self.logger(f'Push options:\n{push_str}', level=2)
         return push_options
 
     def move_tile_cost(self, tile):
@@ -223,7 +201,7 @@ class NinjaBotV002(BaseBot):
             total_value = (nv*4 + ring_of_death_cool) / 5
             if tile in self.pits:
                 total_value = -1
-            mlogger('; '.join([
+            self.logger('; '.join([
                 f'Tile move value {str(tile):<16}',
                 f'Neighbors: {nv:.3f}',
                 f'RoD {ring_of_death_cool:.3f}',
@@ -241,7 +219,7 @@ class NinjaBotV002(BaseBot):
         v += 0.3 * max(0, threatening)
         v -= 0.3 * (neighbor in self.pits)
         v -= 0.7 * max(0, threatened)
-        mlogger(f'- neighbor value {tile} next to {neighbor} : {v:.3f} (push: {threatening} pushed: {threatened})', level=3)
+        self.logger(f'- neighbor value {tile} next to {neighbor} : {v:.3f} (push: {threatening} pushed: {threatened})', level=3)
         return v
 
     def pushed_value(self, tile, neighbor):
@@ -289,5 +267,8 @@ class NinjaBotV002(BaseBot):
         clear_value = 0.25 * (tile_radius - neighbor_radius)
         return result_value + clear_value
 
+    def logger(self, text, level=1):
+        if DEBUG_LEVEL >= level:
+            super().logger(text)
 
 BOT = NinjaBotV002

--- a/bots/ninja002_bot.py
+++ b/bots/ninja002_bot.py
@@ -1,6 +1,7 @@
 # Maintainer: ninja
 import numpy as np
 from bots import BaseBot
+from api.logging import logger
 from api.actions import Idle, Move, Push
 from util.settings import Settings
 from util.hexagon import Hex
@@ -12,7 +13,7 @@ DEBUG_LEVEL = Settings.get('bots.ninja.debug', 0)
 
 def mlogger(*lines, level=1):
     if DEBUG_LEVEL >= level:
-        print('\n'.join(str(_) for _ in lines))
+        logger('\n'.join(str(_) for _ in lines))
 
 
 class NinjaBotV002(BaseBot):
@@ -189,8 +190,8 @@ class NinjaBotV002(BaseBot):
         value_cost = -self.move_tile_value(tile)
         return 1 + obs_cost + value_cost
 
-    def get_path(self, target, debug=False):
-        return a_star(self.pos, target, cost=self.move_tile_cost, debug=debug)
+    def get_path(self, target):
+        return a_star(self.pos, target, cost=self.move_tile_cost)
 
     def get_paths(self, targets, sort=len):
         targets = (t for t in targets if self.move_tile_cost(t) < float('inf'))

--- a/bots/ninja002_bot.py
+++ b/bots/ninja002_bot.py
@@ -8,7 +8,7 @@ from util.hexagon import Hex
 from util.pathfinding import a_star
 
 
-DEBUG_LEVEL = Settings.get('bots.ninja.debug_level', 1)
+DEBUG_LEVEL = Settings.get('logging.bots.ninja.debug_level', 1)
 
 
 class NinjaBotV002(BaseBot):

--- a/bots/spiteful_bot.py
+++ b/bots/spiteful_bot.py
@@ -5,6 +5,7 @@ from bots import BaseBot
 from util.hexagon import Hex, DIAGONALS, is_hex
 from util.settings import Settings
 from util.pathfinding import a_star
+from api.logging import logger as glogger
 from api.actions import Move, Push, Idle
 
 
@@ -14,7 +15,7 @@ LethalSequence = namedtuple('LethalSequence', ['ap_cost', 'actions', 'vfx'])
 
 def logger(m):
     if DEBUG:
-        print(str(m))
+        glogger(str(m))
 
 
 class SpitefulBot(BaseBot):
@@ -97,8 +98,8 @@ class SpitefulBot(BaseBot):
         obs_cost = float('inf') if is_obstacle else 0
         return 1 + obs_cost
 
-    def get_path(self, target, debug=False):
-        return a_star(self.pos, target, cost=self.move_tile_cost, debug=debug)
+    def get_path(self, target):
+        return a_star(self.pos, target, cost=self.move_tile_cost)
 
     def get_paths(self, targets, sort=len):
         targets = (t for t in targets if self.move_tile_cost(t) < float('inf'))

--- a/bots/spiteful_bot.py
+++ b/bots/spiteful_bot.py
@@ -5,17 +5,10 @@ from bots import BaseBot
 from util.hexagon import Hex, DIAGONALS, is_hex
 from util.settings import Settings
 from util.pathfinding import a_star
-from api.logging import logger as glogger
 from api.actions import Move, Push, Idle
 
 
-DEBUG = Settings.get('bots.spiteful.debug', False)
 LethalSequence = namedtuple('LethalSequence', ['ap_cost', 'actions', 'vfx'])
-
-
-def logger(m):
-    if DEBUG:
-        glogger(str(m))
 
 
 class SpitefulBot(BaseBot):
@@ -50,20 +43,20 @@ class SpitefulBot(BaseBot):
     def get_action(self, wi):
         self.update(wi)
         if self.ap < 10:
-            logger(f'Out of AP.')
+            self.logger(f'Out of AP.')
             return Idle()
 
         if not self.current_sequence:
-            logger(f'No sequence.')
+            self.logger(f'No sequence.')
             seqs = self.find_lethal_sequences()
             if seqs:
                 seq_str = '\n'.join(f'{s.ap_cost} AP {" ".join(str(a) for a in s.actions)}' for s in seqs)
-                logger(f'Found sequences:\n{seq_str}')
+                self.logger(f'Found sequences:\n{seq_str}')
                 self.current_sequence = list(seqs[0].actions)
 
         if self.current_sequence:
             s = '\n'.join(f'-> {a}' for a in self.current_sequence)
-            logger(f'Remaining sequence:\n{s}')
+            self.logger(f'Remaining sequence:\n{s}')
             action = self.current_sequence.pop(0)
             return action
 
@@ -84,13 +77,13 @@ class SpitefulBot(BaseBot):
                         break
                 if trunc_path:
                     self.current_sequence = trunc_path
-                    logger(f'Moving to center: {self.current_sequence[0]} {len(self.current_sequence)} steps to target')
+                    self.logger(f'Moving to center: {self.current_sequence[0]} {len(self.current_sequence)} steps to target')
                     return self.current_sequence.pop(0)
-                logger(f'On edge but cannot reach safer tile!')
+                self.logger(f'On edge but cannot reach safer tile!')
             else:
-                logger(f'On edge but no path to center!')
+                self.logger(f'On edge but no path to center!')
 
-        logger(f'Idling.')
+        self.logger(f'Idling.')
         return Idle()
 
     def move_tile_cost(self, tile):
@@ -122,7 +115,7 @@ class SpitefulBot(BaseBot):
         return best_paths[0]
 
     def push_sequence_simple(self, pit, enemy):
-        logger(f'Considering simple push sequence: {enemy} -> {pit}')
+        self.logger(f'Considering simple push sequence: {enemy} -> {pit}')
         # Assert geometry
         assert pit not in self.blocked_pits
         assert pit in enemy.neighbors
@@ -151,11 +144,11 @@ class SpitefulBot(BaseBot):
             {'name': 'push', 'hex': enemy, 'neighbor': pit},
             {'name': 'mark-red', 'hex': pit},
             ]
-        logger(f'Good sequence!')
+        self.logger(f'Good sequence!')
         return LethalSequence(ap_cost, actions, vfx)
 
     def push_sequence_double(self, pit, enemy):
-        logger(f'Considering double push sequence: {enemy} -> {pit}')
+        self.logger(f'Considering double push sequence: {enemy} -> {pit}')
         # Assert geometry
         assert pit not in self.blocked_pits
         assert pit - enemy not in DIAGONALS
@@ -192,11 +185,11 @@ class SpitefulBot(BaseBot):
             {'name': 'push', 'hex': mid_point, 'neighbor': pit},
             {'name': 'mark-red', 'hex': pit},
         ]
-        logger(f'Good sequence!')
+        self.logger(f'Good sequence!')
         return LethalSequence(ap_cost, actions, vfx)
 
     def push_sequence_diag(self, pit, neighbor, enemy):
-        logger(f'Considering diagonal push sequence: {enemy} -> {neighbor} -> {pit}')
+        self.logger(f'Considering diagonal push sequence: {enemy} -> {neighbor} -> {pit}')
         # Assert geometry
         assert pit not in self.blocked_pits
         assert pit - enemy in DIAGONALS
@@ -233,7 +226,7 @@ class SpitefulBot(BaseBot):
             {'name': 'push', 'hex': neighbor, 'neighbor': pit},
             {'name': 'mark-red', 'hex': pit},
         ]
-        logger(f'Good sequence!')
+        self.logger(f'Good sequence!')
         return LethalSequence(ap_cost, actions, vfx)
 
     def find_lethal_sequences(self):
@@ -269,14 +262,6 @@ class SpitefulBot(BaseBot):
         lethal_sequences = sorted(
             lethal_sequences, key=lambda x: x.ap_cost + len(x.actions) / 100)
         return lethal_sequences
-
-    def click_debug(self, hex, button):
-        seqs = self.find_lethal_sequences()
-        if not seqs:
-            return None
-        ap_cost, actions, vfx = seqs[0]
-        logger('\n'.join(str(a) for a in actions))
-        return vfx
 
 
 BOT = SpitefulBot

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import numpy as np
+from api.logging import logger as glogger
 from util.settings import Settings
 
 
@@ -15,4 +16,4 @@ def center_sprite(pos, size):
 
 def logger(m):
     if GUI_DEBUG:
-        print(m)
+        glogger(m)

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -4,7 +4,7 @@ from api.logging import logger as glogger
 from util.settings import Settings
 
 
-GUI_DEBUG = Settings.get('gui.debug', False)
+GUI_DEBUG = Settings.get('logging.gui', False)
 FONT = str(Path.cwd() / 'assets' / 'FiraCode-SemiBold.ttf')
 
 

--- a/gui/cli.py
+++ b/gui/cli.py
@@ -1,5 +1,6 @@
 from collections import Counter
 import numpy as np
+from api.logging import logger
 from logic.maps import SELECTED_MAP_NAME
 
 
@@ -25,16 +26,17 @@ class CLI:
         self.logic_cls = logic_cls
         self.battle = self.logic_cls()
 
-    def new_battle(self):
+    def new_battle(self, do_print=True):
         self.battle = self.logic_cls()
-        self.print_battle()
+        if do_print:
+            self.print_battle()
 
     def print_battle(self):
         print(self.battle.get_match_state())
 
-    def next_step(self, print=True):
+    def next_step(self, do_print=True):
         self.battle.next_step()
-        if print:
+        if do_print:
             self.print_battle()
 
     def play_steps(self, steps):
@@ -65,12 +67,13 @@ class CLI:
             for bot, wins in counter.most_common():
                 print(f'{bot:>20}: {f"{wins/i*100:.2f}":>7} % ({str(wins):<4} wins)')
 
+        logging_enabled_default = logger.enable_logging
+        logger.enable_logging = False
         counter = Counter()
-        last_battle_summary = ''
         for i in range(count):
-            self.new_battle()
-            print(last_battle_summary)
+            self.new_battle(do_print=False)
             print_summary()
+            print('\nPlaying next battle...\n')
             winner, losers = self.play_complete()
             last_battle_summary = self.battle.get_match_state()
             counter[winner] += 1
@@ -78,6 +81,7 @@ class CLI:
                 counter[loser] += 0
         i += 1
         print_summary()
+        logger.enable_logging = logging_enabled_default
 
     def print_help(self):
         print(HELP_STR)

--- a/gui/gui.py
+++ b/gui/gui.py
@@ -10,7 +10,7 @@ from gui.tilemap import TileMap
 FPS = Settings.get('gui._fps', 60)
 WINDOW_SIZE = Settings.get('gui._window_size', [1280, 720])
 START_MAXIMIZED = Settings.get('gui._window_maximize', True)
-LOG_HOTKEYS = Settings.get('gui.log_hotkeys', False)
+LOG_HOTKEYS = Settings.get('logging.hotkeys', False)
 
 
 class App(widgets.App):

--- a/gui/tilemap.py
+++ b/gui/tilemap.py
@@ -14,7 +14,7 @@ MAX_MAP_TILES = Settings.get('tilemap.max_draw_tiles', 2500)
 TILE_PADDING = Settings.get('tilemap._tile_padding', 10)
 MAX_TILE_RADIUS = Settings.get('tilemap.max_tile_radius', 300)
 UNIT_SIZE = Settings.get('tilemap.unit_size', 0.7)
-FONT_SIZE = Settings.get('tilemap.font_size', 20)
+FONT_SCALE = Settings.get('tilemap.font_scale', 0.7)
 REDRAW_COOLDOWN = Settings.get('tilemap.|redraw_cooldown', 0.3)
 ASSETS_DIR = Path.cwd() / 'assets'
 HEX_PNG = str(ASSETS_DIR / 'hex.png')
@@ -429,14 +429,16 @@ class Tile(widgets.kvInstructionGroup):
 
     def set_text(self, bg, fg):
         if fg:
+            font_size = FONT_SCALE * self._bg.size[1] / 2
             self._fg_text.texture = t = widgets.text_texture(fg,
-                font=FONT, font_size=FONT_SIZE)
+                font=FONT, font_size=font_size)
             self._fg_text.size = t.size
             self._fg_text.pos = center_sprite(self.__pos, t.size)
             self._bg_text.size = 0, 0
         elif bg:
+            font_size = FONT_SCALE * self._bg.size[1] / 2
             self._bg_text.texture = t = widgets.text_texture(bg,
-                font=FONT, font_size=FONT_SIZE)
+                font=FONT, font_size=font_size)
             self._bg_text.size = t.size
             self._bg_text.pos = center_sprite(self.__pos, t.size)
             self._fg_text.size = 0, 0

--- a/logic/battle.py
+++ b/logic/battle.py
@@ -282,7 +282,7 @@ class Battle(BaseLogicAPI):
         super().handle_hex_click(hex, button)
         if hex in self.positions:
             bot_id = self.positions.index(hex)
-            vfx_seq = self.bots[bot_id].click_debug(hex, button)
+            vfx_seq = self.bots[bot_id].gui_click(hex, button)
             if vfx_seq is not None:
                 for vfx_kwargs in vfx_seq:
                     vfx_kwargs['steps'] = 1

--- a/logic/maps.py
+++ b/logic/maps.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import itertools
 import random
 import numpy as np
+from api.logging import logger
 from util.settings import Settings
 from util.hexagon import Hex
 
@@ -133,7 +134,7 @@ MAPS = {
     'empty': EmptyMap,
     'giant': GiantMap,
 }
-print('\n'.join([f'Available maps:', *(f'- {m}' for m in MAPS.keys())]))
+logger('\n'.join([f'Available maps:', *(f'- {m}' for m in MAPS.keys())]))
 
 def get_map():
     map = MAPS[SELECTED_MAP_NAME]()

--- a/util/pathfinding.py
+++ b/util/pathfinding.py
@@ -25,7 +25,6 @@ def a_star(origin, target,
         get_neighbors=_get_neighbors,
         heuristic=_heuristic,
         cost=_cost,
-        debug=False,
         ):
     if origin is target:
         return None
@@ -43,21 +42,8 @@ def a_star(origin, target,
         if current is target:
             return _get_full_path(current, came_from)
         open_set.remove(current)
-        if debug:
-            open_set_str = '\n'.join(f'- {n}' for n in best_nodes[:10])
-            print('\n'.join([
-                '_'*50,
-                f'Best nodes score:',
-                *(f'- {n}: {guess_score[n]}' for n in best_nodes[:10]),
-                f'Best nodes distance from origin:',
-                *(f'- {n}: {partial_score[n]}' for n in best_nodes[:10]),
-                '_'*50,
-                f'Current: {current}',
-            ]))
         for neighbor in get_neighbors(current):
             tentative_partial_score = partial_score[current] + cost(neighbor)
-            if debug:
-                print(f'Neighbor: {neighbor} ({tentative_partial_score})')
             if tentative_partial_score < partial_score[neighbor]:
                 came_from[neighbor] = current
                 partial_score[neighbor] = tentative_partial_score


### PR DESCRIPTION
This PR adds a logger (`from api.logging import logger`) to use instead of print. This allows the CLI to disable all logging while running multiple games.

Basebot now has a logger method which is enabled and disabled by right clicking on the unit (no need to manage logging for bots). The method `debug_click` has been refactored and bots should use `gui_click_debug` and `gui_click_debug_alt` instead.

In addition, units are colored grey when dead, and text size in the tilemap now scales.